### PR TITLE
Add support for Feed Me 2

### DIFF
--- a/focuspoint/FocusPointPlugin.php
+++ b/focuspoint/FocusPointPlugin.php
@@ -58,6 +58,16 @@ class FocusPointPlugin extends BasePlugin
 			$asset = $event->params["asset"];
 			craft()->focusPoint_focusPoint->deleteFocusPointRecordsByAssetId($asset->id);
 		});
+
+		Craft::import('plugins.focuspoint.integrations.feedme.fields.FocusPoint_FocusPointFeedMeFieldType');
 	}
+
+	// Feed Me 2.0 Field Type Support
+	public function registerFeedMeFieldTypes()
+    {
+        return array(
+            new FocusPoint_FocusPointFeedMeFieldType(),
+        );
+    }
 
 }

--- a/focuspoint/integrations/feedme/fields/FocusPoint_FocusPointFeedMeFieldType.php
+++ b/focuspoint/integrations/feedme/fields/FocusPoint_FocusPointFeedMeFieldType.php
@@ -1,0 +1,7 @@
+<?php
+namespace Craft;
+
+class FocusPoint_FocusPointFeedMeFieldType extends AssetsFeedMeFieldType
+{
+    // Extends AssetsFeedMeFieldType, so no neeed to re-implement anything   
+}


### PR DESCRIPTION
As per documentation here - http://sgroup.com.au/plugins/feedme/developers/field-types, provides support for Feed Me 2. Its a very simple implementation (none at all really), as FocusPoint is a regular Assets field.