### PR TITLE
Corrects an issue where focal points were being deleted on save, even…

### DIFF
--- a/focuspoint/fieldtypes/FocusPoint_FocusPointFieldType.php
+++ b/focuspoint/fieldtypes/FocusPoint_FocusPointFieldType.php
@@ -73,16 +73,17 @@ class FocusPoint_FocusPointFieldType extends AssetsFieldType
 
     public function onAfterElementSave()
     {
-        craft()->focusPoint_focusPoint->deleteFocusPointRecordsByFieldIdAndSourceId(
-            $this->model->id,
-            $this->element->id
-        );
-
         $hash = spl_object_hash($this->element);
 
         $value = isset($this->values[$hash]) ? $this->values[$hash] : null;
 
         if ($value && isset($value["focus-attr"])) {
+            //since we know we have new data, we can delete the previous records
+            craft()->focusPoint_focusPoint->deleteFocusPointRecordsByFieldIdAndSourceId(
+                $this->model->id,
+                $this->element->id
+            );
+
             $i = 0;
             foreach ($value["focus-attr"] as $focus_attr) {
                 craft()->focusPoint_focusPoint->createOrUpdateFocusPoint(


### PR DESCRIPTION
… when new points were not specified. Fixes #14.

Batch saving entries via command line was dropping all of the FocusPoint records. This pull request corrects that issue.