### PR TITLE
Verify that the key is in index

### DIFF
--- a/focuspoint/fieldtypes/FocusPoint_FocusPointFieldType.php
+++ b/focuspoint/fieldtypes/FocusPoint_FocusPointFieldType.php
@@ -44,7 +44,7 @@ class FocusPoint_FocusPointFieldType extends AssetsFieldType
         $i = 0;
         $array_values = isset($this->values[spl_object_hash($this->element)]["focus-attr"]) ? array_values($this->values[spl_object_hash($this->element)]["focus-attr"]) : array();
         foreach ($parentValues as $parentValue) {
-            if (!empty($array_values)) {
+            if (!empty($array_values) and array_key_exists($i, $array_values)) {
                 $focus_attr = $array_values[$i];
                 $focus_x = $focus_attr["data-focus-x"];
                 $focus_y = $focus_attr["data-focus-y"];


### PR DESCRIPTION
The current check only checks that the array isn't empty, not that it actually contains the value(s) needed.

We can reproduce the error by drag and dropping an image to an existing gallery, which will fail because the new image doesn't currently have a focus point.

this might fix issues like #27 and #24 